### PR TITLE
Builtin Methods

### DIFF
--- a/SocietalConstructionTool/Compiler/IdentifierTable.cs
+++ b/SocietalConstructionTool/Compiler/IdentifierTable.cs
@@ -1,0 +1,101 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Sct.Runtime;
+
+namespace Sct.Compiler
+{
+    public static class IdentifierTable
+    {
+        private static readonly Dictionary<string, MemberAccessExpressionSyntax> Types = new()
+        {
+            { "Rand", BuildAccessor(nameof(Stdlib.Rand), StdlibIdentifier) },
+            { "Seed", BuildAccessor(nameof(Stdlib.Seed), StdlibIdentifier) },
+            { "Exists", BuildAccessor(nameof(IQueryHandler.Exists), ContextIdentifier, QueryHandlerIdentifier) },
+            { "Count", BuildAccessor(nameof(IQueryHandler.Count), ContextIdentifier, QueryHandlerIdentifier) },
+            { "create", BuildAccessor(nameof(IAgentHandler.CreateAgent), ContextIdentifier, AgentHandlerIdentifier) },
+            { "exit", BuildAccessor(nameof(IRuntimeContext.ExitRuntime), ContextIdentifier) },
+        };
+
+        private const string NAME_MANGLE_PREFIX = "__sct_";
+        private static readonly SyntaxToken ContextIdentifier = SyntaxFactory.Identifier("ctx");
+        private static readonly SyntaxToken AgentHandlerIdentifier = SyntaxFactory.Identifier(nameof(IRuntimeContext.AgentHandler));
+        private static readonly SyntaxToken QueryHandlerIdentifier = SyntaxFactory.Identifier(nameof(IRuntimeContext.QueryHandler));
+        private static readonly SyntaxToken StdlibIdentifier = SyntaxFactory.Identifier(nameof(Stdlib));
+
+        private static MemberAccessExpressionSyntax BuildAccessor(string accessor, params SyntaxToken[] members)
+        {
+            return BuildAccessor(SyntaxFactory.Identifier(accessor), members);
+        }
+
+        /// <summary>
+        /// Builds a MemberAccessExpressionSyntax like Foo.Bar.Baz
+        /// </summary>
+        /// <param name="accessor">The last accessor that must be called / invoked</param>
+        /// <param name="members">all members leading up to it, in order</param>
+        /// <returns>a MemberAccessExpressionSyntax corresponding to the parameters</returns>
+        /// <exception cref="ArgumentException">If no `members` are provided</exception>
+        private static MemberAccessExpressionSyntax BuildAccessor(SyntaxToken accessor, params SyntaxToken[] members)
+        {
+            if (members.Length == 0)
+            {
+                throw new ArgumentException("At least one member must be provided");
+            }
+
+            // base case
+            if (members.Length == 1)
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(members[0]),
+                    SyntaxFactory.IdentifierName(accessor)
+                );
+            }
+
+            // left-recursive call
+            return SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                BuildAccessor(members[^1], members[..^1]),
+                SyntaxFactory.IdentifierName(accessor)
+            );
+        }
+
+        public static string GetMangledStringName(string n) => NAME_MANGLE_PREFIX + n;
+
+        /// <summary>
+        /// Get the mangled name of a identifier
+        /// </summary>
+        /// <param name="identifier">identifier as string</param>
+        /// <returns>IdentifierNameSyntax with the mangled name</returns>
+        public static SyntaxToken GetMangledName(string identifier)
+        {
+            return SyntaxFactory.Identifier(GetMangledStringName(identifier));
+        }
+
+        /// <summary>
+        /// Get the (possible) mangled name of a function call
+        /// If the identifier is a reserved keyword, it will map accordingly
+        /// </summary>
+        /// <param name="identifier">identifier from the sct source</param>
+        /// <param name="args">Arguments for the method call - nullable</param>
+        /// <returns>InvocationExpressionSyntax</returns>
+        public static InvocationExpressionSyntax GetFunction(string identifier, ArgumentListSyntax? args)
+        {
+            if (Types.TryGetValue(identifier, out MemberAccessExpressionSyntax? function))
+            {
+                return SyntaxFactory.InvocationExpression(function, args ?? SyntaxFactory.ArgumentList());
+            }
+
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.IdentifierName(GetMangledName(identifier)),
+                args ?? SyntaxFactory.ArgumentList()
+            );
+        }
+
+        public static InvocationExpressionSyntax GetFunction(string identifier, params ArgumentSyntax[]? args)
+        {
+            return GetFunction(identifier, SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(args)));
+        }
+    }
+}

--- a/SocietalConstructionTool/Compiler/TranslatorUtils.cs
+++ b/SocietalConstructionTool/Compiler/TranslatorUtils.cs
@@ -6,25 +6,25 @@ using Sct.Runtime;
 
 namespace Sct.Compiler
 {
-    public static class IdentifierTable
+    public static class TranslatorUtils
     {
-        private static readonly Dictionary<string, MemberAccessExpressionSyntax> Types = new()
-        {
-            { "Rand", BuildAccessor(nameof(Stdlib.Rand), StdlibIdentifier) },
-            { "Seed", BuildAccessor(nameof(Stdlib.Seed), StdlibIdentifier) },
-            { "Exists", BuildAccessor(nameof(IQueryHandler.Exists), ContextIdentifier, QueryHandlerIdentifier) },
-            { "Count", BuildAccessor(nameof(IQueryHandler.Count), ContextIdentifier, QueryHandlerIdentifier) },
-            { "create", BuildAccessor(nameof(IAgentHandler.CreateAgent), ContextIdentifier, AgentHandlerIdentifier) },
-            { "exit", BuildAccessor(nameof(IRuntimeContext.ExitRuntime), ContextIdentifier) },
-        };
-
         private const string NAME_MANGLE_PREFIX = "__sct_";
         private static readonly SyntaxToken ContextIdentifier = SyntaxFactory.Identifier("ctx");
         private static readonly SyntaxToken AgentHandlerIdentifier = SyntaxFactory.Identifier(nameof(IRuntimeContext.AgentHandler));
         private static readonly SyntaxToken QueryHandlerIdentifier = SyntaxFactory.Identifier(nameof(IRuntimeContext.QueryHandler));
         private static readonly SyntaxToken StdlibIdentifier = SyntaxFactory.Identifier(nameof(Stdlib));
 
-        private static MemberAccessExpressionSyntax BuildAccessor(string accessor, params SyntaxToken[] members)
+        // Due to the way static fields are initialized, this field MUST be placed after the identifiers
+        // A full day has gone to waste debugging this...
+        private static readonly Dictionary<string, MemberAccessExpressionSyntax> Types = new()
+        {
+            { "rand", BuildAccessor(nameof(Stdlib.Rand), StdlibIdentifier) },
+            { "seed", BuildAccessor(nameof(Stdlib.Seed), StdlibIdentifier) },
+            { "exists", BuildAccessor(nameof(IQueryHandler.Exists), ContextIdentifier, QueryHandlerIdentifier) },
+            { "count", BuildAccessor(nameof(IQueryHandler.Count), ContextIdentifier, QueryHandlerIdentifier) },
+        };
+
+        public static MemberAccessExpressionSyntax BuildAccessor(string accessor, params SyntaxToken[] members)
         {
             return BuildAccessor(SyntaxFactory.Identifier(accessor), members);
         }
@@ -36,7 +36,7 @@ namespace Sct.Compiler
         /// <param name="members">all members leading up to it, in order</param>
         /// <returns>a MemberAccessExpressionSyntax corresponding to the parameters</returns>
         /// <exception cref="ArgumentException">If no `members` are provided</exception>
-        private static MemberAccessExpressionSyntax BuildAccessor(SyntaxToken accessor, params SyntaxToken[] members)
+        public static MemberAccessExpressionSyntax BuildAccessor(SyntaxToken accessor, params SyntaxToken[] members)
         {
             if (members.Length == 0)
             {

--- a/SocietalConstructionTool/Runtime/Stdlib.cs
+++ b/SocietalConstructionTool/Runtime/Stdlib.cs
@@ -1,0 +1,16 @@
+namespace Sct.Runtime
+{
+    public static class Stdlib
+    {
+        private static Random s_random = new();
+        public static double Rand()
+        {
+            return s_random.NextDouble();
+        }
+
+        public static void Seed(int seed)
+        {
+            s_random = new Random(seed);
+        }
+    }
+}

--- a/SocietalConstructionTool/Runtime/Stdlib.cs
+++ b/SocietalConstructionTool/Runtime/Stdlib.cs
@@ -3,12 +3,12 @@ namespace Sct.Runtime
     public static class Stdlib
     {
         private static Random s_random = new();
-        public static double Rand()
+        public static double Rand(IRuntimeContext _)
         {
             return s_random.NextDouble();
         }
 
-        public static void Seed(int seed)
+        public static void Seed(IRuntimeContext _, int seed)
         {
             s_random = new Random(seed);
         }

--- a/SocietalConstructionToolTests/Snapshots/TranslatorTests/AgentPredicate.verified.txt
+++ b/SocietalConstructionToolTests/Snapshots/TranslatorTests/AgentPredicate.verified.txt
@@ -6,10 +6,10 @@
     {
         public static void __sct_f(IRuntimeContext ctx)
         {
-            __sct_exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { new KeyValuePair<String, dynamic>("__sct_a", 2), new KeyValuePair<String, dynamic>("__sct_b", 3) })));
-            __sct_exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
-            __sct_exists(ctx, new QueryPredicate("__sct_Foo", null, new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { new KeyValuePair<String, dynamic>("__sct_a", 3) })));
-            __sct_exists(ctx, new QueryPredicate("__sct_Foo", null, new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
+            ctx.QueryHandler.Exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { new KeyValuePair<String, dynamic>("__sct_a", 2), new KeyValuePair<String, dynamic>("__sct_b", 3) })));
+            ctx.QueryHandler.Exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
+            ctx.QueryHandler.Exists(ctx, new QueryPredicate("__sct_Foo", null, new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { new KeyValuePair<String, dynamic>("__sct_a", 3) })));
+            ctx.QueryHandler.Exists(ctx, new QueryPredicate("__sct_Foo", null, new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
         }
 
         public class __sct_Foo : BaseAgent

--- a/SocietalConstructionToolTests/Snapshots/TranslatorTests/BuiltinFunctions.verified.txt
+++ b/SocietalConstructionToolTests/Snapshots/TranslatorTests/BuiltinFunctions.verified.txt
@@ -6,10 +6,10 @@
     {
         public static void __sct_f(IRuntimeContext ctx)
         {
-            __sct_exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
-            __sct_count(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
-            __sct_rand(ctx);
-            __sct_seed(ctx, 123);
+            ctx.QueryHandler.Exists(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
+            ctx.QueryHandler.Count(ctx, new QueryPredicate("__sct_Foo", "__sct_Bar", new Dictionary<String, dynamic>(new KeyValuePair<String, dynamic>[] { })));
+            Stdlib.Rand(ctx);
+            Stdlib.Seed(ctx, 123);
         }
 
         public class __sct_Foo : BaseAgent


### PR DESCRIPTION
Don't know if we should create more generic helpers in the `TranslatorUtils` class, for creating a method with both accessors and arguments, like we do in `MakeMainMethod()`.

Also, a lot of the static methods in general, could probably be moved there.

Closes #133 
Closes #128 