### PR TITLE
Fix code generation on functions

### DIFF
--- a/SocietalConstructionTool/Compiler/Translator/SctTranslator.cs
+++ b/SocietalConstructionTool/Compiler/Translator/SctTranslator.cs
@@ -55,6 +55,8 @@ namespace Sct.Compiler.Translator
             Root = @namespace;
         }
 
+        public override void EnterClass_def([NotNull] SctParser.Class_defContext context) => _isInAgent = true;
+
         public override void ExitClass_def([NotNull] SctParser.Class_defContext context)
         {
             _isInAgent = false;

--- a/SocietalConstructionTool/Runtime/IQueryHandler.cs
+++ b/SocietalConstructionTool/Runtime/IQueryHandler.cs
@@ -2,7 +2,7 @@ namespace Sct.Runtime
 {
     public interface IQueryHandler
     {
-        public int Count(IQueryPredicate predicate);
-        public bool Exists(IQueryPredicate predicate);
+        public int Count(IRuntimeContext ctx, IQueryPredicate predicate);
+        public bool Exists(IRuntimeContext ctx, IQueryPredicate predicate);
     }
 }

--- a/SocietalConstructionTool/Runtime/QueryHandler.cs
+++ b/SocietalConstructionTool/Runtime/QueryHandler.cs
@@ -4,8 +4,7 @@ namespace Sct.Runtime
     {
         private IEnumerable<BaseAgent> Filter(IQueryPredicate predicate) => agents.Where(predicate.Test);
 
-        public int Count(IQueryPredicate predicate) => Filter(predicate).Count();
-
-        public bool Exists(IQueryPredicate predicate) => Filter(predicate).Any();
+        public int Count(IRuntimeContext ctx, IQueryPredicate predicate) => Filter(predicate).Count();
+        public bool Exists(IRuntimeContext ctx, IQueryPredicate predicate) => Filter(predicate).Any();
     }
 }


### PR DESCRIPTION
Fixed two different bugs in the translator
1. We pass a context argument to all functions we call, but `Count` and `Exists` didn't accept these arguments, so they have been added
2. We didn't set the `isInAgent` flag in the translator when we entered a class definition, causing all generated class methods to be static