### PR TITLE
Create method to get parser and cleanup snapshot tests

### DIFF
--- a/SocietalConstructionTool/SctRunner.cs
+++ b/SocietalConstructionTool/SctRunner.cs
@@ -16,6 +16,30 @@ namespace Sct
 {
     public static class SctRunner
     {
+        /// <summary>
+        /// Return the parser for the given SCT source file
+        /// </summary>
+        /// <param name="filename">File to parse</param>
+        /// <returns>The parser from ANTLR</returns>
+        public static SctParser GetParser(string filename) =>
+            GetSctParser(File.ReadAllText(filename));
+
+        /// <summary>
+        /// Return the parser for the given SCT source file asynchronously
+        /// </summary>
+        /// <param name="filename">File to parse</param>
+        /// <returns>The parser from ANTLR</returns>
+        public static async Task<SctParser> GetParserAsync(string filename) =>
+            GetSctParser(await File.ReadAllTextAsync(filename));
+
+        private static SctParser GetSctParser(string input)
+        {
+            ICharStream stream = CharStreams.fromString(input);
+            ITokenSource lexer = new SctLexer(stream);
+            ITokenStream tokens = new CommonTokenStream(lexer);
+            return new SctParser(tokens);
+        }
+
         /**
          * <summary>
          * Reads an SCT source file, statically chekcs it and translates it into C# code
@@ -25,7 +49,6 @@ namespace Sct
          */
         public static (string? outputText, IEnumerable<CompilerError> errors) CompileSct(string[] filenames)
         {
-
             // Make SctTableVisitor take a CTableBuilder as a parameter
             // Analyse each file separately
             // Add file name to each found error.
@@ -42,14 +65,8 @@ namespace Sct
             // Run static analysis on each file separately.
             foreach (var file in filenames)
             {
-                string input = File.ReadAllText(file);
-                ICharStream fileStream = CharStreams.fromString(input);
-                ITokenSource fileLexer = new SctLexer(fileStream);
-                ITokenStream fileTokens = new CommonTokenStream(fileLexer);
-
-                var fileParser = new SctParser(fileTokens);
                 // Save parser for later use.
-                startNodes[file] = fileParser.start();
+                startNodes[file] = GetParser(file).start();
                 var startNode = startNodes[file];
 
                 KeywordContextCheckVisitor keywordChecker = new();

--- a/SocietalConstructionToolTests/AbstractSnapshotTests.cs
+++ b/SocietalConstructionToolTests/AbstractSnapshotTests.cs
@@ -2,10 +2,10 @@ namespace SocietalConstructionToolTests
 {
     public abstract class AbstractSnapshotTests : VerifyBase
     {
-        // yield all files in TestFiles directory
-        protected static IEnumerable<string[]> Files =>
-            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles/Parser"))
-            .Select(f => new[] { f });
+        // yield all files in some subdirectory of the TestFiles directory
+        protected static IEnumerable<string[]> GetTestFiles(string dir) =>
+            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", dir))
+                .Select(f => new[] { f });
 
 
         [ClassInitialize(InheritanceBehavior.BeforeEachDerivedClass)]

--- a/SocietalConstructionToolTests/BehaviourTests.cs
+++ b/SocietalConstructionToolTests/BehaviourTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 using Sct;
 using Sct.Runtime.Trace;
 
@@ -8,10 +6,7 @@ namespace SocietalConstructionToolTests
     [TestClass]
     public class BehaviourTests : AbstractSnapshotTests
     {
-
-        private static new IEnumerable<string[]> Files =>
-            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", "BehaviourTests"))
-            .Select(f => new[] { f });
+        private static IEnumerable<string[]> Files => GetTestFiles("BehaviourTests");
 
         // Run each file as a seperate test
         [DataTestMethod]
@@ -32,5 +27,4 @@ namespace SocietalConstructionToolTests
                 .UseFileName(Path.GetFileNameWithoutExtension(file));
         }
     }
-
 }

--- a/SocietalConstructionToolTests/ParserTests.cs
+++ b/SocietalConstructionToolTests/ParserTests.cs
@@ -1,11 +1,11 @@
-using Antlr4.Runtime;
+using Sct;
 
 namespace SocietalConstructionToolTests
 {
     [TestClass]
     public class ParserTests : AbstractSnapshotTests
     {
-        private static new IEnumerable<string[]> Files => AbstractSnapshotTests.Files;
+        private static IEnumerable<string[]> Files => GetTestFiles("Parser");
 
         [DataTestMethod]
         [DynamicData(nameof(Files), DynamicDataSourceType.Property)]
@@ -13,12 +13,8 @@ namespace SocietalConstructionToolTests
         {
             UseProjectRelativeDirectory("Snapshots/ParserTests"); // save snapshots here
 
-            string input = await File.ReadAllTextAsync(testFile);
-            ICharStream stream = CharStreams.fromString(input);
-            ITokenSource lexer = new SctLexer(stream);
-            ITokenStream tokens = new CommonTokenStream(lexer);
-            SctParser parser = new(tokens);
-            SctParser.StartContext result = parser.start();
+            var parser = await SctRunner.GetParserAsync(testFile);
+            var result = parser.start();
 
             _ = await Verify(result.ToStringTree(parser))
                 .UseFileName(Path.GetFileNameWithoutExtension(testFile));

--- a/SocietalConstructionToolTests/SplitFileTests.cs
+++ b/SocietalConstructionToolTests/SplitFileTests.cs
@@ -7,10 +7,7 @@ namespace SocietalConstructionToolTests
     [TestClass]
     public class SplitFileTests : AbstractSnapshotTests
     {
-        private static new IEnumerable<string[]> Files =>
-            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", "SplitFileTests"))
-            .Select(f => new[] { f });
-
+        private static IEnumerable<string[]> Files => GetTestFiles("SplitFileTests");
 
         [DataTestMethod]
         public async Task RunFiles()
@@ -21,7 +18,7 @@ namespace SocietalConstructionToolTests
 
             var (outputText, errors) = SctRunner.CompileSct(files);
 
-            Assert.IsTrue(errors.Count() == 0, string.Join("\n", errors));
+            Assert.IsFalse(errors.Any(), string.Join("\n", errors));
             Assert.IsNotNull(outputText);
             _ = await Verify(outputText)
                 .UseFileName(Path.GetFileNameWithoutExtension(files[0]));

--- a/SocietalConstructionToolTests/StaticCheckerTests.cs
+++ b/SocietalConstructionToolTests/StaticCheckerTests.cs
@@ -1,5 +1,4 @@
-using Antlr4.Runtime;
-
+using Sct;
 using Sct.Compiler.Typechecker;
 
 namespace SocietalConstructionToolTests
@@ -7,10 +6,7 @@ namespace SocietalConstructionToolTests
     [TestClass]
     public class StaticCheckerTests : AbstractSnapshotTests
     {
-
-        private static new IEnumerable<string[]> Files =>
-            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles", "StaticCheckTests"))
-            .Select(f => new[] { f });
+        private static IEnumerable<string[]> Files => GetTestFiles("StaticCheckTests");
 
         // Run each file as a seperate test
         [DataTestMethod]
@@ -19,12 +15,7 @@ namespace SocietalConstructionToolTests
         {
             UseProjectRelativeDirectory("Snapshots/StaticCheckTests"); // save snapshots here
 
-            string input = File.ReadAllText(file);
-            ICharStream stream = CharStreams.fromString(input);
-            ITokenSource lexer = new SctLexer(stream);
-            ITokenStream tokens = new CommonTokenStream(lexer);
-            SctParser parser = new(tokens);
-
+            SctParser parser = await SctRunner.GetParserAsync(file);
             var startNode = parser.start();
 
             KeywordContextCheckVisitor keywordChecker = new();
@@ -34,5 +25,4 @@ namespace SocietalConstructionToolTests
                 .UseFileName(Path.GetFileNameWithoutExtension(file));
         }
     }
-
 }

--- a/SocietalConstructionToolTests/TranslatorTests.cs
+++ b/SocietalConstructionToolTests/TranslatorTests.cs
@@ -1,7 +1,6 @@
-using Antlr4.Runtime;
-
 using Microsoft.CodeAnalysis;
 
+using Sct;
 using Sct.Compiler.Translator;
 
 namespace SocietalConstructionToolTests
@@ -9,7 +8,7 @@ namespace SocietalConstructionToolTests
     [TestClass]
     public class TranslatorTests : AbstractSnapshotTests
     {
-        private static new IEnumerable<string[]> Files => AbstractSnapshotTests.Files;
+        private static IEnumerable<string[]> Files => GetTestFiles("Parser");
 
         // Run each file as a seperate test
         [DataTestMethod]
@@ -18,11 +17,7 @@ namespace SocietalConstructionToolTests
         {
             UseProjectRelativeDirectory("Snapshots/TranslatorTests"); // save snapshots here
 
-            string input = File.ReadAllText(file);
-            ICharStream stream = CharStreams.fromString(input);
-            ITokenSource lexer = new SctLexer(stream);
-            ITokenStream tokens = new CommonTokenStream(lexer);
-            SctParser parser = new(tokens);
+            SctParser parser = await SctRunner.GetParserAsync(file);
             var listener = new SctTranslator();
             parser.AddParseListener(listener);
             _ = parser.start();

--- a/SocietalConstructionToolTests/TypecheckerTests.cs
+++ b/SocietalConstructionToolTests/TypecheckerTests.cs
@@ -1,22 +1,13 @@
-using Antlr4.Runtime;
-
+using Sct;
 using Sct.Compiler;
 using Sct.Compiler.Typechecker;
 
 namespace SocietalConstructionToolTests
 {
     [TestClass]
-    public class TypeCheckerTests : VerifyBase
+    public class TypeCheckerTests : AbstractSnapshotTests
     {
-        private static IEnumerable<string[]> Files =>
-            Directory.GetFiles(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestFiles/Typechecker"))
-            .Select(f => new[] { f });
-
-        [ClassInitialize]
-        public static void Setup(TestContext _)
-        {
-            DiffEngine.DiffRunner.Disabled = true; // avoid destroying your terminal
-        }
+        private static IEnumerable<string[]> Files => GetTestFiles("Typechecker");
 
         [DataTestMethod]
         [DynamicData(nameof(Files), DynamicDataSourceType.Property)]
@@ -24,14 +15,9 @@ namespace SocietalConstructionToolTests
         {
             UseProjectRelativeDirectory("Snapshots/TypeCheckerTests"); // save snapshots here
 
-            string input = await File.ReadAllTextAsync(testFile);
-            ICharStream stream = CharStreams.fromString(input);
-            ITokenSource lexer = new SctLexer(stream);
-            ITokenStream tokens = new CommonTokenStream(lexer);
-
-            List<CompilerError> errors = new();
-            SctParser parser = new(tokens);
+            SctParser parser = await SctRunner.GetParserAsync(testFile);
             SctParser.StartContext startNode = parser.start();
+            List<CompilerError> errors = new();
 
             var returnChecker = new SctReturnCheckVisitor();
             _ = startNode.Accept(returnChecker);


### PR DESCRIPTION
Changed the way test files are accessed, as they all access different sub-directories.

And created a method to get the parser, which is something we do both in tests and when we compile.

ie.
```cs
var input = File.ReadAllText(filename);
ICharStream stream = CharStreams.fromString(input);
ITokenSource lexer = new SctLexer(stream);
ITokenStream tokens = new CommonTokenStream(lexer);
var parser = new SctParser(tokens);
```