### PR TITLE
correct folding with const below dynamic

### DIFF
--- a/SocietalConstructionToolTests/Snapshots/Ast/Folding/BinaryExpressions.verified.txt
+++ b/SocietalConstructionToolTests/Snapshots/Ast/Folding/BinaryExpressions.verified.txt
@@ -320,6 +320,58 @@
                   Value: 1,
                   Type: Int
                 }
+              },
+              {
+                $type: SctAssignmentStatementSyntax,
+                Id: x,
+                Expression: {
+                  $type: SctParenthesisExpressionSyntax,
+                  Expression: {
+                    $type: SctBinaryExpressionSyntax,
+                    Left: {
+                      $type: SctIdExpressionSyntax,
+                      Id: x
+                    },
+                    Right: {
+                      $type: SctLiteralExpressionSyntax<long>,
+                      Value: 12,
+                      Type: Int
+                    },
+                    Op: Plus
+                  }
+                }
+              },
+              {
+                $type: SctAssignmentStatementSyntax,
+                Id: x,
+                Expression: {
+                  $type: SctNotExpressionSyntax,
+                  Expression: {
+                    $type: SctParenthesisExpressionSyntax,
+                    Expression: {
+                      $type: SctBinaryExpressionSyntax,
+                      Left: {
+                        $type: SctBinaryExpressionSyntax,
+                        Left: {
+                          $type: SctLiteralExpressionSyntax<long>,
+                          Value: 2,
+                          Type: Int
+                        },
+                        Right: {
+                          $type: SctIdExpressionSyntax,
+                          Id: x
+                        },
+                        Op: Mult
+                      },
+                      Right: {
+                        $type: SctLiteralExpressionSyntax<long>,
+                        Value: 0,
+                        Type: Int
+                      },
+                      Op: Div
+                    }
+                  }
+                }
               }
             ]
           }

--- a/SocietalConstructionToolTests/Snapshots/Ast/FoldingErrors/BinaryExpressions.verified.txt
+++ b/SocietalConstructionToolTests/Snapshots/Ast/FoldingErrors/BinaryExpressions.verified.txt
@@ -4,5 +4,11 @@
     Line: 17,
     Column: 12,
     Filename: null
+  },
+  {
+    Message: Division by zero,
+    Line: 47,
+    Column: 10,
+    Filename: null
   }
 ]

--- a/SocietalConstructionToolTests/TestFiles/FoldingTests/BinaryExpressions.sct
+++ b/SocietalConstructionToolTests/TestFiles/FoldingTests/BinaryExpressions.sct
@@ -41,4 +41,8 @@ function Setup() -> void {
     b = 0 || 0;
     b = !1;
     b = !0;
+
+    // Partial folds
+    x = (x+3*4);
+    x = !((1 + 1) * x / (1-1));
 }


### PR DESCRIPTION
Constants were not properly folded previously, if the expression was lower in the AST than a non-foldable expression. As an example, (x + 1/(1-2)) was not folded, as () didn't see a foldable child expression, and then just returned itself. Now the base method is used to create a clone anyway. Also catches additional divisoin by zero errors, as they were only caught if the entire division was foldable.

